### PR TITLE
Use merged data map so that trigger can override job parameters 

### DIFF
--- a/java/twarc/TwarcJob.java
+++ b/java/twarc/TwarcJob.java
@@ -2,7 +2,6 @@ package twarc;
 
 import org.quartz.Job;
 import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import clojure.lang.IFn;
 import clojure.lang.Keyword;
@@ -19,7 +18,7 @@ public class TwarcJob implements Job {
     }
 
     public void execute(JobExecutionContext context) {
-        JobDataMap m = context.getJobDetail().getJobDataMap();
+        JobDataMap m = context.getMergedJobDataMap();
         IFn list = Clojure.var("clojure.core", "list*");
         ISeq args = (ISeq) list.invoke(scheduler.assoc(Keyword.intern("twarc", "execution-context"), context), m.get("arguments"));
         f.applyTo(args);

--- a/java/twarc/TwarcStatefullJob.java
+++ b/java/twarc/TwarcStatefullJob.java
@@ -4,7 +4,6 @@ import org.quartz.Job;
 import org.quartz.PersistJobDataAfterExecution;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import clojure.lang.IFn;
 import clojure.lang.Keyword;
@@ -23,7 +22,7 @@ public class TwarcStatefullJob implements Job {
     }
 
     public void execute(JobExecutionContext context) {
-        JobDataMap m = context.getJobDetail().getJobDataMap();
+        JobDataMap m = context.getMergedJobDataMap();
         IFn list = Clojure.var("clojure.core", "list*");
         ISeq args = (ISeq) list.invoke(scheduler.assoc(Keyword.intern("twarc", "execution-context"), context), m.get("state"), m.get("arguments"));
         Object result = f.applyTo(args);

--- a/test/twarc/core_test.clj
+++ b/test/twarc/core_test.clj
@@ -40,7 +40,7 @@
                            :state "(.)(.)"})
 
       (let [res (async-res listener)
-            data-map (-> (.getJobDetail res) (.getJobDataMap))]
+            data-map (.getMergedJobDataMap res)]
         (is (= "(.)(.)(.)" (get data-map "state"))))))
 
   (testing "named jobs"

--- a/test/twarc/core_test.clj
+++ b/test/twarc/core_test.clj
@@ -50,7 +50,20 @@
                 :trigger {:cron "*/10 * * * * ?"})
     (is (true? (twarc/check-job-exists *scheduler* "task-3")))
     (twarc/delete-job *scheduler* "task-3")
-    (is (false? (twarc/check-job-exists *scheduler* "task-3")))))
+    (is (false? (twarc/check-job-exists *scheduler* "task-3"))))
+
+  (testing "trigger can override job parameters"
+    (let [listener (twarc/add-listener *scheduler*
+                                       {:key ["test-suite" "task-4"]} :to-be-executed)]
+      (simple-job *scheduler* []
+                  :job {:identity "task-4"
+                        :group "test-suite"}
+                  :trigger {:job-data {"arguments" ["Petr" "Yanovich"]}
+                            :cron "*/10 * * * * ?"})
+      (let [res (async-res listener)
+            data-map (.getMergedJobDataMap res)]
+        (is (= ["Petr" "Yanovich"] (get data-map "arguments")))
+        (is (= nil (get data-map "state")))))))
 
 (deftest remove-listener-test
   (testing "Remove a listener"


### PR DESCRIPTION
This is to enable one job having multiple triggers with differing "arguments" for the job var execution

Something like the following allows us to add another trigger:
```
(defn add-trigger
  "Add trigger to an existing job in the scheduler. a job can have multiple triggers."
  [job-name job-group trigger-map]
  (let [trigger (twarc/make-trigger (assoc trigger-map :for-job (twarc/job-key job-group job-name)))]
    (.scheduleJob ^Scheduler (:twarc/quartz scheduler) trigger)))
```

I need to refine this and create another pull request for trigger handling api. In the mean time this pull request will allow me to start playing with it 