### PR TITLE
Use 2.2.1 methods for requestRecovery and storeDurably

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject twarc "0.1.10"
+(defproject twarc "0.1.11"
   :description "Doing Quartz the right way"
   :url "https://github.com/prepor/twarc"
   :license {:name "Eclipse Public License"

--- a/src/twarc/core.clj
+++ b/src/twarc/core.clj
@@ -29,8 +29,8 @@
        group (.withIdentity identity group)
        (not group) (.withIdentity identity)
        desc (.withDescription desc)
-       durably (.withDurably)
-       recovery (.withRecovery))
+       durably (.storeDurably durably)
+       recovery (.requestRecovery recovery))
       (.build)))
 
 (defn prepare-simple


### PR DESCRIPTION
The original methods don't seem to be declared in the version of docs linked
from README, but these similarly named methods are. 

I'm not sure if requestRecovery actually does anything, I've tried setting up a durable job store and clustered mode and I'm not seeing any difference with this flag being turned on.

Closes #8. 